### PR TITLE
created constants and gui submodules

### DIFF
--- a/build_and_upload.bat
+++ b/build_and_upload.bat
@@ -1,5 +1,5 @@
 echo "This should be run from inside the Thonny shell"
-timeout /T 10 /NOBREAK
+timeout /T 5 /NOBREAK
 
 del /Q dist\*
 python setup.py sdist bdist_wheel

--- a/build_and_upload.bat
+++ b/build_and_upload.bat
@@ -1,5 +1,5 @@
 echo "This should be run from inside the Thonny shell"
-timeout /T 5 /NOBREAK
+timeout /T 2 /NOBREAK
 
 del /Q dist\*
 python setup.py sdist bdist_wheel

--- a/docs/sparki_learning_quick_reference.txt
+++ b/docs/sparki_learning_quick_reference.txt
@@ -2,7 +2,7 @@
 Sparki Learning Command Quick Reference
 ======================================================
 
-for version 1.5.2 of the python library
+for version 1.6.0 of the python library
 
 (this library makes use of Python 3; Python 2.7 should work, but testing is limited)
 
@@ -316,13 +316,13 @@ Several of the commands (ask(), askQuestion(), joystick(), pickAFile() and yesor
 
 ask(message, title = "Question")
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-	Creates window with message. User is allowed to input a response. Returns the user's response. See the section on Common Variables for an explanation of message. title is optional and defaults to "Question". (Note that if this appears to do nothing, the window with the output may be hidden behind other windows.)
+	Creates window with message. User is allowed to input a response. Returns the user's response. See the section on Common Variables for an explanation of message. title is optional and defaults to "Question". (Note that if this appears to do nothing, the window with the output may be hidden behind other windows.) (Moved to sparki_learning.gui in v1.6.0.)
 
 
 
 askQuestion(message, options, title = "Question")
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-	Creates window with message, with buttons labeled with options. options must be a list of strings. Returns the user's response. See the section on Common Variables for an explanation of message. Loops until user gives a value in options. title is optional and defaults to "Question". (Note that if this appears to do nothing, the window with the output may be hidden behind other windows.)
+	Creates window with message, with buttons labeled with options. options must be a list of strings. Returns the user's response. See the section on Common Variables for an explanation of message. Loops until user gives a value in options. title is optional and defaults to "Question". (Note that if this appears to do nothing, the window with the output may be hidden behind other windows.) (Moved to sparki_learning.gui in v1.6.0.)
 
 
 
@@ -344,15 +344,21 @@ joystick()
 
 
 
+messageWindow(message, title = "Message")
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+	Strictly speaking, this is not an input command, but it does display a message to the user and "pause" your program until the user clicks okay.
+
+
+
 pickAFile()
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-	Creates window with a file dialog so that the user can pick a file. Might be useful for reading from or saving to a file.
+	Creates window with a file dialog so that the user can pick a file. Might be useful for reading from or saving to a file. (Moved to sparki_learning.gui in v1.6.0.)
 
 
 
 yesorno(message)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-	Creates window with message, with buttons labeled with "yes" and "no". Returns the user's response (which will be either "yes" or "no"). See the section on Common Variables for an explanation of message.
+	Creates window with message, with buttons labeled with "yes" and "no". Returns the user's response (which will be either "yes" or "no"). See the section on Common Variables for an explanation of message. (Moved to sparki_learning.gui in v1.6.0.)
 
 
 
@@ -442,7 +448,7 @@ print(message)
 	
 printDebug(message, priority = DEBUG_WARN, output = sys.stderr)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-	Prints message to output if the current debug level (set by `setDebug(level)`_ and defaulting to DEBUG_WARN) is greater than or equal to priority. output defaults to standard error. Included for convenience of writing your own functions. message must be a string (i.e. message does not accept multiple arguments like speak or print).
+	Prints message to output if the current debug level (set by `setDebug(level)`_ and defaulting to DEBUG_WARN) is greater than or equal to priority. output defaults to standard error. Included for convenience of writing your own functions. message must be a string (i.e. message does not accept multiple arguments like speak or print). (Moved to sparki_learning.util in 1.5.2.dev2)
 	
 
 	

--- a/examples/sparki_myro_test_gui.py
+++ b/examples/sparki_myro_test_gui.py
@@ -3,10 +3,15 @@ from __future__ import print_function
 
 from sparki_learning import *
 
+messageWindow("This will test some of the Sparki GUI functions")
+
 result = ask("What is your name? ")
 print("The user said " + result)
 
 result = yesorno("Click yes or no")
+print("The user said " + result)
+
+result = askQuestion("Choose a shape ", [ 'square', 'circle' ])
 print("The user said " + result)
 
 result = askQuestion_text("Type a shape ", [ 'square', 'circle' ], False)

--- a/examples/sparki_myro_test_logging.py
+++ b/examples/sparki_myro_test_logging.py
@@ -3,32 +3,30 @@ from __future__ import print_function
 
 from sparki_learning import *
 
-import logging
+# for version 1.6.0.0 and above of the library
 
-# for version 1.5.0.0 and above of the library
-
-print("This program tests out logging in the sparki library -- must be using version > 1.5.0.0")
+print("This program tests out logging in the sparki library -- must be using version > 1.6.0.0")
 print("Your current version is {}".format(getVersion()[0]))
 printDebug("Check to see if printDebug works with the default level")
 
 print("The logging levels are:")
-print("{} is logging.DEBUG".format(logging.DEBUG))
-print("{} is logging.INFO".format(logging.INFO))
-print("{} is logging.WARN".format(logging.WARN))
-print("{} is logging.ERROR".format(logging.ERROR))
-print("{} is logging.CRITICAL".format(logging.CRITICAL))
+print("{} is DEBUG_DEBUG".format(DEBUG_DEBUG))
+print("{} is DEBUG_INFO".format(DEBUG_INFO))
+print("{} is DEBUG_WARN".format(DEBUG_WARN))
+print("{} is DEBUG_ERROR".format(DEBUG_ERROR))
+print("{} is DEBUG_CRITICAL".format(DEBUG_CRITICAL))
 
-for logging_level in (logging.DEBUG, logging.INFO, logging.WARN, logging.ERROR, logging.CRITICAL):
+for logging_level in (DEBUG_DEBUG, DEBUG_INFO, DEBUG_WARN, DEBUG_ERROR, DEBUG_CRITICAL):
     setDebug(logging_level)
 
-    for message_level in (logging.DEBUG, logging.INFO, logging.WARN, logging.ERROR, logging.CRITICAL):
+    for message_level in (DEBUG_DEBUG, DEBUG_INFO, DEBUG_WARN, DEBUG_ERROR, DEBUG_CRITICAL):
         printDebug("Checking logging level {} with message level {}".format(logging_level, message_level), message_level)
 
 print("That was increasing levels of severity -- now do decreasing")
 
-for logging_level in (logging.CRITICAL, logging.ERROR, logging.WARN, logging.INFO, logging.DEBUG):
+for logging_level in (DEBUG_CRITICAL, DEBUG_ERROR, DEBUG_WARN, DEBUG_INFO, DEBUG_DEBUG):
     setDebug(logging_level)
 
-    for message_level in (logging.CRITICAL, logging.ERROR, logging.WARN, logging.INFO, logging.DEBUG):
+    for message_level in (DEBUG_CRITICAL, DEBUG_ERROR, DEBUG_WARN, DEBUG_INFO, DEBUG_DEBUG):
         printDebug("Checking logging level {} with message level {}".format(logging_level, message_level), message_level)
 

--- a/examples/sparki_myro_test_movement_time.py
+++ b/examples/sparki_myro_test_movement_time.py
@@ -5,7 +5,7 @@ from sparki_learning import *
 
 com_port = None     # replace with your COM port or /dev/
 
-setDebug(logging.INFO)
+setDebug(DEBUG_INFO)
 
 while not com_port:
     com_port = input("What is your com port or /dev/? ")

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@
 #
 # written by Jeremy Eglen
 # Created: February 24, 2016
-# Last Modified: November 14, 2019
+# Last Modified: November 18, 2019
 # originally written targeting Python 3.4 and 3.5, some testing on 3.6 and has been lightly tested with Python 2.7
 # working with Python 3.7 & 3.8
 
@@ -21,7 +21,7 @@ with open(path.join(this_directory, 'README.md'), encoding='utf-8') as f:
 
 setup(
     name = "sparki_learning",
-    version = "1.6.0.dev1",
+    version = "1.6.0.dev4",
     packages = find_packages(),
 
     # Project uses pyserial for bluetooth, so ensure that package gets

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@
 # written by Jeremy Eglen
 # Created: February 24, 2016
 # Last Modified: November 18, 2019
-# originally written targeting Python 3.4 and 3.5, some testing on 3.6 and has been lightly tested with Python 2.7
+# originally written targeting Python 3.4 and 3.5
 # working with Python 3.7 & 3.8
 
 from setuptools import setup, find_packages
@@ -19,9 +19,14 @@ this_directory = path.abspath(path.dirname(__file__))
 with open(path.join(this_directory, 'README.md'), encoding='utf-8') as f:
     long_description = f.read()
 
+# get the version number from the constants file
+with open(path.join(this_directory, "sparki_learning", "constants.py"), encoding='utf-8') as fc:
+    exec(fc.read())
+print("sparki_learning version is {}".format(SPARKI_MYRO_VERSION))
+
 setup(
     name = "sparki_learning",
-    version = "1.6.0.dev4",
+    version = SPARKI_MYRO_VERSION,
     packages = find_packages(),
 
     # Project uses pyserial for bluetooth, so ensure that package gets

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@
 #
 # written by Jeremy Eglen
 # Created: February 24, 2016
-# Last Modified: November 13, 2019
+# Last Modified: November 14, 2019
 # originally written targeting Python 3.4 and 3.5, some testing on 3.6 and has been lightly tested with Python 2.7
 # working with Python 3.7 & 3.8
 
@@ -21,12 +21,12 @@ with open(path.join(this_directory, 'README.md'), encoding='utf-8') as f:
 
 setup(
     name = "sparki_learning",
-    version = "1.5.2.dev2",
+    version = "1.6.0.dev1",
     packages = find_packages(),
 
     # Project uses pyserial for bluetooth, so ensure that package gets
     # installed or upgraded on the target machine
-    install_requires = ['pyserial>=2.7'],
+    install_requires = ['pyserial>=2.7', 'pysimplegui>=4.0.0'],
 
     python_requires='>=2.7, <4',
 

--- a/sparki_learning/__init__.py
+++ b/sparki_learning/__init__.py
@@ -21,10 +21,12 @@
     <https://sparki-learning.readthedocs.io/en/latest/>
 """
 
+from sparki_learning.constants import *
 from sparki_learning.gui import *
 from sparki_learning.sparki_myro import *
 from sparki_learning.speak import speak
 from sparki_learning.sync_lib import get_client_start, start_sync_server, start_sync_client
 from sparki_learning.util import *
 
+import sparki_learning.constants
 import sparki_learning.sparki_myro

--- a/sparki_learning/__init__.py
+++ b/sparki_learning/__init__.py
@@ -21,6 +21,7 @@
     <https://sparki-learning.readthedocs.io/en/latest/>
 """
 
+from sparki_learning.gui import *
 from sparki_learning.sparki_myro import *
 from sparki_learning.speak import speak
 from sparki_learning.sync_lib import get_client_start, start_sync_server, start_sync_client

--- a/sparki_learning/constants.py
+++ b/sparki_learning/constants.py
@@ -1,0 +1,150 @@
+################## Sparki Learning Library Constants ##################
+#
+# This file contains various constants used by the Sparki Learning Library
+#
+# Sparki is a mark of Arcbotics, LLC; no claim is made to the name Sparki and all rights in the name Sparki
+# remain property of their respective owners
+#
+# Previously, this was a part of sparki_myro.py -- it was broken out for flexibility
+#
+# written by Jeremy Eglen
+# Created: November 18, 2019
+# Last Modified: November 18, 2019
+
+########### CONSTANTS ###########
+# ***** VERSION NUMBER ***** #
+SPARKI_MYRO_VERSION = "1.6.0"  # this may differ from the version on Sparki itself
+
+# ***** MESSAGE TERMINATOR ***** #
+TERMINATOR = chr(23)  # this character is at the end of every message to / from Sparki
+
+# ***** SYNC ***** #
+SYNC = chr(22)  # this character is sent by Sparki after every command completes so we know it's ready for the next
+
+# ***** MISCELLANEOUS VARIABLES ***** #
+SECS_PER_CM = .4  # number of seconds it takes sparki to move 1 cm; estimated from observation - may vary depending on batteries and robot
+SECS_PER_DEGREE = .03  # number of seconds it takes sparki to rotate 1 degree; estimated from observation - may vary depending on batteries and robot
+MAX_TRANSMISSION = 20  # maximum message length is 20 to conserve Sparki's limited RAM
+
+LCD_BLACK = 0  # set in Sparki.h
+LCD_WHITE = 1  # set in Sparki.h
+
+# ***** COMMAND CHARACTER CODES ***** #
+# Sparki Myro works by sending commands over the serial port (bluetooth) to Sparki from Python
+# This is the list of possible command codes; note that it is possible for some commands to be turned off at Sparki's level (e.g. the Accel, Mag)
+COMMAND_CODES = {
+    'BEEP': 'b',  # requires 2 arguments: int freq and int time; returns nothing
+    'COMPASS': 'c',  # no arguments; returns float heading
+    'GAMEPAD': 'e',  # no arguments; returns nothing
+    'GET_ACCEL': 'f',  # no arguments; returns array of 3 floats with values of x, y, and z
+    #'GET_BATTERY': 'j',  # no arguments; returns float of voltage remaining
+    'GET_LIGHT': 'k',  # no arguments; returns array of 3 ints with values of left, center & right light sensor
+    'GET_LINE': 'm',
+    # no arguments; returns array of 5 ints with values of left edge, left, center, right & right edge line sensor
+    'GET_MAG': 'o',  # no arguments; returns array of 3 floats with values of x, y, and z
+    'GRIPPER_CLOSE_DIS': 'v',  # requires 1 argument: float distance to close the gripper; returns nothing
+    'GRIPPER_OPEN_DIS': 'x',  # requires 1 argument: float distance to open the gripper; returns nothing
+    'GRIPPER_STOP': 'y',  # no arguments; returns nothing
+    'INIT': 'z',  # no arguments; confirms communication between computer and robot
+    'LCD_CLEAR': '0',  # no arguments; returns nothing
+    ## below LCD commands removed for compacting purposes
+    ##'LCD_DRAW_CIRCLE':'1',    # requires 4 arguments: int x&y, int radius, and int filled (1 is filled); returns nothing
+    ##'LCD_DRAW_LINE': '2',
+    # requires 4 arguments ints x&y for start point and x1&y1 for end points; returns nothing; EXT_LCD_1 must be True
+    'LCD_DRAW_PIXEL': '3',  # requires 2 arguments: int x&y; returns nothing
+    ##'LCD_DRAW_RECT':'4',# requires 5 arguments: int x&y for start point, ints width & height, and int filled (1 is filled); returns nothing
+    'LCD_DRAW_STRING': '5',
+    # requires 3 arguments: int x (column), int line_number, and char* string; returns nothing; EXT_LCD_1 must be True
+    'LCD_PRINT': '6',  # requires 1 argument: char* string; returns nothing
+    'LCD_PRINTLN': '7',  # requires 1 argument: char* string; returns nothing
+    'LCD_READ_PIXEL': '8',
+    # requires 2 arguments: int x&y; returns int color of pixel at that point; EXT_LCD_1 must be True
+    'LCD_SET_COLOR': 'T',  # requires 1 argument: int color; returns nothing; EXT_LCD_1 must be True
+    'LCD_UPDATE': '9',  # no arguments; returns nothing
+    'MOTORS': 'A',  # requires 3 arguments: int left_speed (1-100), int right_speed (1-100), & float time
+    # if time < 0, motors will begin immediately and will not stop; returns nothing
+    'BACKWARD_CM': 'B',  # requires 1 argument: float cm to move backward; returns nothing
+    'FORWARD_CM': 'C',  # requires 1 argument: float cm to move forward; returns nothing
+    'PING': 'D',  # no arguments; returns ping at current servo position
+    'RECEIVE_IR': 'E',  # no arguments; returns an int read from the IR sensor
+    'SEND_IR': 'F',  # requires 1 argument: int to send on the IR sender; returns nothing
+    'SERVO': 'G',  # requires 1 argument: int servo position; returns nothing
+    'SET_DEBUG_LEVEL': 'H',  # requires 1 argument: int debug level (0-5); returns nothing; SPARKI_DEBUGS must be True
+    'SET_RGB_LED': 'I',  # requires 3 arguments: int red, int green, int blue; returns nothing
+    'SET_STATUS_LED': 'J',  # requires 1 argument: int brightness of LED; returns nothing
+    'STOP': 'K',  # no arguments; returns nothing
+    'TURN_BY': 'L',  # requires 1 argument: float degrees to turn - if degrees is positive, turn clockwise,
+    # if degrees is negative, turn counterclockwise; returns nothing
+    'GET_NAME': 'O',  # get the Sparki's name as stored in the EEPROM - USE_EEPROM must be True
+    # if the name was not set previously, can give undefined behavior
+    'SET_NAME': 'P',  # set the Sparki's name in the EEPROM - USE_EEPROM must be True
+    'READ_EEPROM': 'Q',  # reads data as stored in the EEPROM - USE_EEPROM & EXT_LCD_1 must be True
+    'WRITE_EEPROM': 'R',  # writes data to the EEPROM - USE_EEPROM & EXT_LCD_1 must be True
+    'NOOP': 'Z'  # does nothing and returns nothing - NOOP must be True
+}
+# ***** END OF COMMAND CHARACTER CODES ***** #
+
+# ***** DEBUG CONSTANTS ***** #
+# these are the debug levels used on the sparki itself in case the SPARKI_DEBUGS capability is set to True
+DEBUG_DEBUG = 5  # reports just about everything
+DEBUG_INFO = 4  # reports entering functions
+DEBUG_WARN = 3  # a generally sane default; reports issues that may be mistakes, but don't interfere with operation
+DEBUG_ERROR = 2  # reports something contrary to the API
+DEBUG_CRITICAL = 1  # reports an error which interferes with proper or consistent operation
+DEBUG_ALWAYS = 0  # should always be reported
+
+# ***** SENSOR POSITION CONSTANTS ***** #
+# LINE SENSORS #
+LINE_EDGE_RIGHT = 4
+LINE_MID_RIGHT = 3
+LINE_MID = 2
+LINE_MID_LEFT = 1
+LINE_EDGE_LEFT = 0
+
+# LIGHT SENSORS #
+LIGHT_SENS_RIGHT = 2
+LIGHT_SENS_MID = 1
+LIGHT_SENS_LEFT = 0
+
+# ***** MAX GRIPPER DISTANCE ***** #
+MAX_GRIPPER_DISTANCE = 7.0
+
+# ***** EEPROM STORAGE ***** #
+EEPROM_BLUETOOTH_ADDRESS = 80
+EEPROM_NAME_MAX_CHARS = 20
+EEPROM_MAX_ADDRESS = 1023
+
+# ***** SERVO POSITIONS ***** #
+SERVO_LEFT = -80
+SERVO_CENTER = 0
+SERVO_RIGHT = 80
+
+# ***** TABLE OF CAPABILITIES ***** #
+# this dictionary stores the capabilities of various versions of the program running on the Sparki itself
+# this is used in init to update the capabilities of the Sparki -- you could use this so that the library can
+#   work with different versions of the Sparki library
+# The order of the fields is NO_ACCEL, NO_MAG, SPARKI_DEBUGS, USE_EEPROM, EXT_LCD_1, reserved, NOOP
+# If a version number contains a lower case r, everything after the r will be stripped when determining the capabilities
+#   for example, 1.1.2r1 and 1.1.2r5 will have the same capabilities
+SPARKI_CAPABILITIES = {"z": (True, True, False, False, False, False, False),
+                       "DEBUG": (True, True, True, False, False, False, False),
+                       "DEBUG-ACCEL": (False, True, True, False, False, False, False),
+                       "DEBUG-EEPROM": (True, True, True, True, False, False, False),
+                       "DEBUG-LCD": (False, False, True, False, True, False, False),
+                       "DEBUG-MAG": (True, False, True, False, False, False, False),
+                       "DEBUG-PING": (True, True, True, False, False, False, False),
+                       "0.2 No Mag / No Accel": (True, True, False, False, False, False, False),
+                       "0.8.3 Mag / Accel On": (False, False, False, False, False, False, False),
+                       "0.9.6": (False, False, False, True, False, False, False),
+                       "0.9.7": (False, False, False, True, False, False, False),
+                       "0.9.8": (False, False, False, True, False, False, False),
+                       "1.0.0": (False, False, False, True, False, False, False),
+                       "1.0.1": (False, False, False, True, True, False, False),
+                       "1.1.0": (False, False, False, True, True, False, False),
+                       "1.1.1": (False, False, False, True, True, False, False),
+                       "1.1.2": (False, False, False, True, True, False, False),
+                       "1.1.3": (False, False, False, True, True, False, True),
+                       "1.1.4": (False, False, False, True, True, False, True)}
+
+########### END OF CONSTANTS ###########
+

--- a/sparki_learning/gui.py
+++ b/sparki_learning/gui.py
@@ -43,6 +43,78 @@ def ask(message, mytitle="Question"):
     return result
 
 
+def askQuestion(message, options, mytitle="Question"):
+    """ Gets input from the user -- prints message and displays buttons with options
+
+        arguments:
+        message - string to print to prompt the user
+        options - a list of strings which could be the response
+        mytitle - title for the window (defaults to Question)
+
+        returns:
+        string response from the user
+    """
+    printDebug("In askQuestion, message={}; options={}; mytitle={}".format(message, options, mytitle), sparki_learning.util.DEBUG_INFO)
+    radio_group = "options"
+
+    try:
+        radio = [[sg.Radio(text, radio_group, key=text),] for text in options]
+        layout = [[sg.Text(message)]] + radio + [[sg.OK(), sg.Cancel()]]
+        window = sg.Window(mytitle, layout)
+
+        while True:             # Event Loop
+            event, values = window.Read()
+            if event in (None, "OK", "Cancel"):
+                break
+
+        printDebug("In askQuestion, event = {}; values = {}".format(event,values), sparki_learning.util.DEBUG_DEBUG)
+        window.close()
+
+        result = False
+        for text in options:
+            if window[text].get():
+                result = text
+
+    except Exception as err:
+        printDebug("Error creating askQuestion window -- gui may not be available", sparki_learning.util.DEBUG_ERROR)
+        printDebug(str(err), sparki_learning.util.DEBUG_DEBUG)
+        result = askQuestion_text(message, options, False)
+
+    return result
+
+
+def askQuestion_text(message, options, caseSensitive=True):
+    """ Gets a string from the user, which must be one of the options -- prints message
+        (this is called if askQuestion fails)
+
+        arguments:
+        message - string to print to prompt the user
+        options - list of options for the user to choose
+        caseSensitive - boolean, if True, response must match case
+
+        returns:
+        string response from the user (if caseSentitive is False, this will always be a lower case string)
+    """
+    if not caseSensitive:  # if we're not caseSensitive, make the options lower case
+        working_options = [s.lower() for s in options]
+    else:
+        working_options = options
+
+    result = input(message)
+
+    if not caseSensitive:
+        result = result.lower()
+
+    while result not in working_options:
+        print("Your answer must be one of the following: " + str(options))
+        result = input(message)
+
+        if not caseSensitive:
+            result = result.lower()
+
+    return result
+
+
 def messageWindow(message, mytitle="Message"):
     """ Pauses the program with a GUI message
 
@@ -61,7 +133,7 @@ def messageWindow(message, mytitle="Message"):
     except Exception as err:
         printDebug("Error creating message window -- gui may not be available", sparki_learning.util.DEBUG_ERROR)
         printDebug(str(err), sparki_learning.util.DEBUG_DEBUG)
-        input(message + " (Press Enter to continue)")
+        input(message + " (Press Enter to continue) ")
 
 
 def pickAFile():
@@ -86,6 +158,20 @@ def pickAFile():
     return result
 
 
+def yesorno(message):
+    """ Gets the string 'yes' or 'no' from the user -- prints message
+
+        arguments:
+        message - string to print to prompt the user
+
+        returns:
+        string response from the user
+    """
+    printDebug("In yesorno", DEBUG_INFO)
+
+    return askQuestion(message, ["yes", "no"], "Yes or No?")
+
+
 def main():
     messageWindow("This will test the functions in this library.\nNormally, you include this file in your program.\nFor example:\nfrom sparki_learning.gui import *", "sparki_learning.gui test")
 
@@ -102,6 +188,13 @@ def main():
         messageWindow("You typed \'" + ask_test + "\'")
     else:
         messageWindow("You did not type anything (or pressed X or cancel)")
+        
+    # askQuestion test
+    askQuestion_test = askQuestion("Choose wisely:", ["yes", "no", "maybe so"], "askQuestion() demo")
+    if askQuestion_test:
+        messageWindow("You chose \'" + askQuestion_test + "\'")
+    else:
+        messageWindow("You did not choose anything (or pressed X or cancel)")
     
     messageWindow("Done with sparki_learning.gui tests", "All Done!")
 

--- a/sparki_learning/gui.py
+++ b/sparki_learning/gui.py
@@ -1,0 +1,110 @@
+################## Sparki Learning Library GUI Functions ##################
+#
+# This file contains various gui functions used by the Sparki Learning Library
+#
+# Sparki is a mark of Arcbotics, LLC; no claim is made to the name Sparki and all rights in the name Sparki
+# remain property of their respective owners
+#
+# written by Jeremy Eglen
+# Created: November 14, 2019
+# Last Modified: November 14, 2019
+from __future__ import print_function
+
+from sparki_learning.util import printDebug
+
+import sys
+if sys.version_info[0] >= 3:
+    import PySimpleGUI as sg
+else:
+    import PySimpleGUI27 as sg
+    
+import sparki_learning.util
+
+def ask(message, mytitle="Question"):
+    """ Gets input from the user -- prints message
+
+        arguments:
+        message - string to print to prompt the user
+        mytitle - title for the window (defaults to Question)
+
+        returns:
+        string response from the user
+    """
+    printDebug("In ask, message={}; mytitle={}".format(message, mytitle), sparki_learning.util.DEBUG_INFO)
+
+    try:
+        result = sg.PopupGetText(message, title=mytitle)
+        
+    except Exception as err:
+        printDebug("Error creating ask window -- gui may not be available", sparki_learning.util.DEBUG_ERROR)
+        printDebug(str(err), DEBUG_DEBUG)
+        result = input(message)
+
+    return result
+
+
+def messageWindow(message, mytitle="Message"):
+    """ Pauses the program with a GUI message
+
+        arguments:
+        message - string to print to prompt the user
+        mytitle - title for the window (defaults to Message)
+
+        returns:
+        nothing
+    """
+    printDebug("In messageWindow, message={}; mytitle={}".format(message, mytitle), sparki_learning.util.DEBUG_INFO)
+
+    try:
+        sg.Popup(message, title=mytitle, keep_on_top=True)
+        
+    except Exception as err:
+        printDebug("Error creating message window -- gui may not be available", sparki_learning.util.DEBUG_ERROR)
+        printDebug(str(err), sparki_learning.util.DEBUG_DEBUG)
+        input(message + " (Press Enter to continue)")
+
+
+def pickAFile():
+    """ Gets the path to a file picked by the user
+
+        arguments:
+        none
+
+        returns:
+        string path to the file
+    """
+    printDebug("In pickAFile", sparki_learning.util.DEBUG_INFO)
+
+    try:
+        result = sg.PopupGetFile("Choose a file")
+        
+    except Exception as err:
+        printDebug("Error creating pickAFile window -- gui may not be available", sparki_learning.util.DEBUG_ERROR)
+        printDebug(str(err), sparki_learning.util.DEBUG_DEBUG)
+        result = input("What is the path to the file? ")
+
+    return result
+
+
+def main():
+    messageWindow("This will test the functions in this library.\nNormally, you include this file in your program.\nFor example:\nfrom sparki_learning.gui import *", "sparki_learning.gui test")
+
+    # pickAFile() test
+    file_test = pickAFile()
+    if file_test:
+        messageWindow("You picked \'" + file_test + "\' as your file")
+    else:
+        messageWindow("You did not pick a file")
+        
+    # ask test
+    ask_test = ask("Type some stuff:", "ask() demo")
+    if ask_test:
+        messageWindow("You typed \'" + ask_test + "\'")
+    else:
+        messageWindow("You did not type anything (or pressed X or cancel)")
+    
+    messageWindow("Done with sparki_learning.gui tests", "All Done!")
+
+
+if __name__ == "__main__":
+    main()

--- a/sparki_learning/gui.py
+++ b/sparki_learning/gui.py
@@ -7,7 +7,7 @@
 #
 # written by Jeremy Eglen
 # Created: November 14, 2019
-# Last Modified: November 14, 2019
+# Last Modified: November 18, 2019
 from __future__ import print_function
 
 from sparki_learning.util import printDebug
@@ -95,6 +95,7 @@ def askQuestion_text(message, options, caseSensitive=True):
         returns:
         string response from the user (if caseSentitive is False, this will always be a lower case string)
     """
+    printDebug("In askQuestion_text, message={}; options={}; caseSensitive={}".format(message, options, caseSensitive), sparki_learning.util.DEBUG_INFO)
     if not caseSensitive:  # if we're not caseSensitive, make the options lower case
         working_options = [s.lower() for s in options]
     else:
@@ -167,7 +168,7 @@ def yesorno(message):
         returns:
         string response from the user
     """
-    printDebug("In yesorno", DEBUG_INFO)
+    printDebug("In yesorno", sparki_learning.util.DEBUG_INFO)
 
     return askQuestion(message, ["yes", "no"], "Yes or No?")
 

--- a/sparki_learning/sparki_myro.py
+++ b/sparki_learning/sparki_myro.py
@@ -17,30 +17,28 @@
 # working with Python 3.7
 
 from __future__ import division, \
-    print_function  # in case this is run from Python 2.6 or greater, but less than Python 3
+    print_function  # in case this is run from Python 2.7 or greater, but less than Python 3
 
-import datetime
 import logging
 import math
-import os
 import platform
 import sys
-import serial  # developed with pyserial 2.7, but also tested extensively with 3.1
+import serial  # developed with pyserial 2.7, but also works with later versions
 import time
 
+from sparki_learning.constants import *
 from sparki_learning.util import *
 
-########### CONSTANTS ###########
-# ***** VERSION NUMBER ***** #
-SPARKI_MYRO_VERSION = "1.6.0.dev2"  # this may differ from the version on Sparki itself and from the library as a whole
 
-# ***** MESSAGE TERMINATOR ***** #
-TERMINATOR = chr(23)  # this character is at the end of every message to / from Sparki
-
-# ***** SYNC ***** #
-SYNC = chr(22)  # this character is sent by Sparki after every command completes so we know it's ready for the next
-
+########### GLOBAL VARIABLES ###########
+# ***** SERIAL TIMEOUT ***** #
+if platform.system() == "Darwin":  # Macs seem to be extremely likely to timeout -- so this is a lower value
+    CONN_TIMEOUT = 2  # in seconds
+else:
+    CONN_TIMEOUT = 5  # in seconds
+    
 # ***** COMPILE OPTIONS ***** #
+# these may change upon initialization, but should not change thereafter
 # some commands may be turned off in the version of sparki myro running on Sparki
 # these will be reset during the initialization process depending on the version (see the SPARKI_CAPABILITIES variable)
 NO_MAG = False  # compass(), getMag(), getMagX(), getMagY(), getMagZ()
@@ -50,142 +48,8 @@ USE_EEPROM = False  # EEPROMread(), EEPROMwrite(), getName(), setName()
 EXT_LCD_1 = False  # EEPROMread(), EEPROMwrite(), LCDdrawLine(), LCDdrawString(), LCDreadPixel()
 NOOP = False  # noop() -- if False, noop is simulated with setStatusLED
 
-# ***** MISCELLANEOUS VARIABLES ***** #
-SECS_PER_CM = .4  # number of seconds it takes sparki to move 1 cm; estimated from observation - may vary depending on batteries and robot
-SECS_PER_DEGREE = .03  # number of seconds it takes sparki to rotate 1 degree; estimated from observation - may vary depending on batteries and robot
-MAX_TRANSMISSION = 20  # maximum message length is 20 to conserve Sparki's limited RAM
-
-LCD_BLACK = 0  # set in Sparki.h
-LCD_WHITE = 1  # set in Sparki.h
-
-# ***** SERIAL TIMEOUT ***** #
-if platform.system() == "Darwin":  # Macs seem to be extremely likely to timeout -- so this is a lower value
-    CONN_TIMEOUT = 2  # in seconds
-else:
-    CONN_TIMEOUT = 5  # in seconds
-
-# ***** COMMAND CHARACTER CODES ***** #
-# Sparki Myro works by sending commands over the serial port (bluetooth) to Sparki from Python
-# This is the list of possible command codes; note that it is possible for some commands to be turned off at Sparki's level (e.g. the Accel, Mag)
-COMMAND_CODES = {
-    'BEEP': 'b',  # requires 2 arguments: int freq and int time; returns nothing
-    'COMPASS': 'c',  # no arguments; returns float heading
-    'GAMEPAD': 'e',  # no arguments; returns nothing
-    'GET_ACCEL': 'f',  # no arguments; returns array of 3 floats with values of x, y, and z
-    #'GET_BATTERY': 'j',  # no arguments; returns float of voltage remaining
-    'GET_LIGHT': 'k',  # no arguments; returns array of 3 ints with values of left, center & right light sensor
-    'GET_LINE': 'm',
-    # no arguments; returns array of 5 ints with values of left edge, left, center, right & right edge line sensor
-    'GET_MAG': 'o',  # no arguments; returns array of 3 floats with values of x, y, and z
-    'GRIPPER_CLOSE_DIS': 'v',  # requires 1 argument: float distance to close the gripper; returns nothing
-    'GRIPPER_OPEN_DIS': 'x',  # requires 1 argument: float distance to open the gripper; returns nothing
-    'GRIPPER_STOP': 'y',  # no arguments; returns nothing
-    'INIT': 'z',  # no arguments; confirms communication between computer and robot
-    'LCD_CLEAR': '0',  # no arguments; returns nothing
-    ## below LCD commands removed for compacting purposes
-    ##'LCD_DRAW_CIRCLE':'1',    # requires 4 arguments: int x&y, int radius, and int filled (1 is filled); returns nothing
-    ##'LCD_DRAW_LINE': '2',
-    # requires 4 arguments ints x&y for start point and x1&y1 for end points; returns nothing; EXT_LCD_1 must be True
-    'LCD_DRAW_PIXEL': '3',  # requires 2 arguments: int x&y; returns nothing
-    ##'LCD_DRAW_RECT':'4',# requires 5 arguments: int x&y for start point, ints width & height, and int filled (1 is filled); returns nothing
-    'LCD_DRAW_STRING': '5',
-    # requires 3 arguments: int x (column), int line_number, and char* string; returns nothing; EXT_LCD_1 must be True
-    'LCD_PRINT': '6',  # requires 1 argument: char* string; returns nothing
-    'LCD_PRINTLN': '7',  # requires 1 argument: char* string; returns nothing
-    'LCD_READ_PIXEL': '8',
-    # requires 2 arguments: int x&y; returns int color of pixel at that point; EXT_LCD_1 must be True
-    'LCD_SET_COLOR': 'T',  # requires 1 argument: int color; returns nothing; EXT_LCD_1 must be True
-    'LCD_UPDATE': '9',  # no arguments; returns nothing
-    'MOTORS': 'A',  # requires 3 arguments: int left_speed (1-100), int right_speed (1-100), & float time
-    # if time < 0, motors will begin immediately and will not stop; returns nothing
-    'BACKWARD_CM': 'B',  # requires 1 argument: float cm to move backward; returns nothing
-    'FORWARD_CM': 'C',  # requires 1 argument: float cm to move forward; returns nothing
-    'PING': 'D',  # no arguments; returns ping at current servo position
-    'RECEIVE_IR': 'E',  # no arguments; returns an int read from the IR sensor
-    'SEND_IR': 'F',  # requires 1 argument: int to send on the IR sender; returns nothing
-    'SERVO': 'G',  # requires 1 argument: int servo position; returns nothing
-    'SET_DEBUG_LEVEL': 'H',  # requires 1 argument: int debug level (0-5); returns nothing; SPARKI_DEBUGS must be True
-    'SET_RGB_LED': 'I',  # requires 3 arguments: int red, int green, int blue; returns nothing
-    'SET_STATUS_LED': 'J',  # requires 1 argument: int brightness of LED; returns nothing
-    'STOP': 'K',  # no arguments; returns nothing
-    'TURN_BY': 'L',  # requires 1 argument: float degrees to turn - if degrees is positive, turn clockwise,
-    # if degrees is negative, turn counterclockwise; returns nothing
-    'GET_NAME': 'O',  # get the Sparki's name as stored in the EEPROM - USE_EEPROM must be True
-    # if the name was not set previously, can give undefined behavior
-    'SET_NAME': 'P',  # set the Sparki's name in the EEPROM - USE_EEPROM must be True
-    'READ_EEPROM': 'Q',  # reads data as stored in the EEPROM - USE_EEPROM & EXT_LCD_1 must be True
-    'WRITE_EEPROM': 'R',  # writes data to the EEPROM - USE_EEPROM & EXT_LCD_1 must be True
-    'NOOP': 'Z'  # does nothing and returns nothing - NOOP must be True
-}
-# ***** END OF COMMAND CHARACTER CODES ***** #
-
-
-# ***** DEBUG CONSTANTS ***** #
-# these are the debug levels used on the sparki itself in case the SPARKI_DEBUGS capability is set to True
-DEBUG_DEBUG = 5  # reports just about everything
-DEBUG_INFO = 4  # reports entering functions
-DEBUG_WARN = 3  # a generally sane default; reports issues that may be mistakes, but don't interfere with operation
-DEBUG_ERROR = 2  # reports something contrary to the API
-DEBUG_CRITICAL = 1  # reports an error which interferes with proper or consistent operation
-DEBUG_ALWAYS = 0  # should always be reported
-
-# ***** SENSOR POSITION CONSTANTS ***** #
-# LINE SENSORS #
-LINE_EDGE_RIGHT = 4
-LINE_MID_RIGHT = 3
-LINE_MID = 2
-LINE_MID_LEFT = 1
-LINE_EDGE_LEFT = 0
-
-# LIGHT SENSORS #
-LIGHT_SENS_RIGHT = 2
-LIGHT_SENS_MID = 1
-LIGHT_SENS_LEFT = 0
-
-# ***** MAX GRIPPER DISTANCE ***** #
-MAX_GRIPPER_DISTANCE = 7.0
-
-# ***** EEPROM STORAGE ***** #
-EEPROM_BLUETOOTH_ADDRESS = 80
-EEPROM_NAME_MAX_CHARS = 20
-EEPROM_MAX_ADDRESS = 1023
-
-# ***** SERVO POSITIONS ***** #
-SERVO_LEFT = -80
-SERVO_CENTER = 0
-SERVO_RIGHT = 80
-
-# ***** TABLE OF CAPABILITIES ***** #
-# this dictionary stores the capabilities of various versions of the program running on the Sparki itself
-# this is used in init to update the capabilities of the Sparki -- you could use this so that the library can
-#   work with different versions of the Sparki library
-# The order of the fields is NO_ACCEL, NO_MAG, SPARKI_DEBUGS, USE_EEPROM, EXT_LCD_1, reserved, NOOP
-# If a version number contains a lower case r, everything after the r will be stripped when determining the capabilities
-#   for example, 1.1.2r1 and 1.1.2r5 will have the same capabilities
-SPARKI_CAPABILITIES = {"z": (True, True, False, False, False, False, False),
-                       "DEBUG": (True, True, True, False, False, False, False),
-                       "DEBUG-ACCEL": (False, True, True, False, False, False, False),
-                       "DEBUG-EEPROM": (True, True, True, True, False, False, False),
-                       "DEBUG-LCD": (False, False, True, False, True, False, False),
-                       "DEBUG-MAG": (True, False, True, False, False, False, False),
-                       "DEBUG-PING": (True, True, True, False, False, False, False),
-                       "0.2 No Mag / No Accel": (True, True, False, False, False, False, False),
-                       "0.8.3 Mag / Accel On": (False, False, False, False, False, False, False),
-                       "0.9.6": (False, False, False, True, False, False, False),
-                       "0.9.7": (False, False, False, True, False, False, False),
-                       "0.9.8": (False, False, False, True, False, False, False),
-                       "1.0.0": (False, False, False, True, False, False, False),
-                       "1.0.1": (False, False, False, True, True, False, False),
-                       "1.1.0": (False, False, False, True, True, False, False),
-                       "1.1.1": (False, False, False, True, True, False, False),
-                       "1.1.2": (False, False, False, True, True, False, False),
-                       "1.1.3": (False, False, False, True, True, False, True),
-                       "1.1.4": (False, False, False, True, True, False, True)}
-
-########### END OF CONSTANTS ###########
-
-########### GLOBAL VARIABLES ###########
-command_queue = []  # this stores every command sent to Sparki; I don't have a use for it right now...
+# ***** RUNTIME OPTIONS ***** #
+command_queue = []  # this stores every command sent to Sparki
 
 centimeters_moved = 0  # this stores the sum of centimeters moved forward or backward using the moveForwardcm()
 # or moveBackwardcm() functions; used implicitly by moveTo() and moveBy(); use directly
@@ -405,35 +269,6 @@ def music_sunrise():
     beep(1000, 1047)
 
 
-def printDebug(message, priority=logging.WARN):
-    """ Logs message given the priority specified 
-    
-        arguments:
-        message - the string message to be logged
-        priority - the integer priority of the message; uses the priority levels in the logging module
-
-        returns:
-        nothing
-    """
-    # this function (and hence the library) originally did not use the logging module from the standard library
-    global sparki_logger
-
-    # for compatibility, we will recognize the "old" priority levels, but new code should be written to conform to the
-    # priority levels in the logging module
-    if priority == DEBUG_DEBUG or priority == logging.DEBUG:
-        sparki_logger.debug(message)
-    elif priority == DEBUG_INFO or priority == logging.INFO:
-        sparki_logger.info(message)
-    elif priority == DEBUG_WARN or priority == logging.WARN:
-        sparki_logger.warn(message)
-    elif priority == DEBUG_ERROR or priority == logging.ERROR:
-        sparki_logger.error(message)
-    elif priority == DEBUG_CRITICAL or priority == logging.CRITICAL:
-        sparki_logger.critical(message)
-    else:
-        print("[{}] --- {}".format(time.ctime(), message), file=sys.stderr)
-
-
 def printUnableToConnect():
     """ Prints a troubleshooting message
 
@@ -446,7 +281,7 @@ def printUnableToConnect():
     print("Unable to connect with Sparki", file=sys.stderr)
     print("Ensure that:", file=sys.stderr)
     print("    1) Sparki is turned on", file=sys.stderr)
-    print("    2) Sparki's Bluetooth module is inserted", file=sys.stderr)
+    print("    2) Sparki's Bluetooth module is inserted correctly", file=sys.stderr)
     print("    3) Your computer's Bluetooth has been paired with Sparki", file=sys.stderr)
     print("    4) Sparki's batteries have some power left", file=sys.stderr)
     print("If you see the Sparki logo on the LCD, press reset on the Sparki and try to reconnect -- you may have to do this many times.", file=sys.stderr)
@@ -1336,10 +1171,7 @@ def init(com_port, print_versions=True):
         init_time = -1
 
 
-def initialize(com_port):
-    """ Synonym for init(com_port)
-    """
-    init(com_port)
+initialize = init # Synonym for init(com_port)
 
 
 def isMoving():
@@ -1384,20 +1216,22 @@ def joystick():
         else:
             import PySimpleGUI27 as sg
         
-        moving_message = "Sparki is moving"
-        not_moving_message = "Sparki is not moving"
+        robot_name = getName()
+
+        moving_message = "{} is moving".format(robot_name)
+        not_moving_message = "{} is not moving".format(robot_name)
         
-        print("Sparki will not respond to other commands until the joystick window is closed")
+        print("{} will not respond to other commands until the joystick window is closed".format(robot_name))
         
         layout = [[sg.Button('Forward')],
                   [sg.Button('Left'), sg.Button('Stop'), sg.Button('Right')],
                   [sg.Button('Backward')],
                   [sg.Button('Open'), sg.Button('Close')],
                   [sg.Button('Head Left'), sg.Button('Head Center'), sg.Button('Head Right')],
-                  [sg.Text('Last Click:'), sg.Text('                         ', key='_ACTION_')],
+                  [sg.Text('Last Click:'), sg.Text('', key='_ACTION_', size=(18,1))],
                   [sg.Text(not_moving_message, key='_MOTION_')],
                   [sg.Button('Exit')],
-                  [sg.Text('You must close this window to give other commands to Sparki')]]
+                  [sg.Text('You must close this window to give other commands to {}'.format(robot_name))]]
 
         window = sg.Window('Joystick - Drive your Sparki', layout, auto_size_text = True,
                            auto_size_buttons = True, resizable = True,
@@ -2065,7 +1899,7 @@ def sendIR(sendMe):
 
 
 def senses():
-    """ Displays readings from Sparki's sensors (lines, light, ping, mag, accel, compass, battery)
+    """ Displays readings from Sparki's sensors (lines, light, ping, mag, accel, compass)
 
         arguments:
         none
@@ -2073,6 +1907,7 @@ def senses():
         returns:
         nothing
     """
+    global NO_MAG, NO_ACCEL
     printDebug("In senses", DEBUG_INFO)
 
     # grid is 9 rows by 6 columns
@@ -2084,140 +1919,156 @@ def senses():
     #    mag   |     N/A     |        |          |         |
     #   accel  |     N/A     |        |          |         |     N/A
     #          |             |        |          |         |
-    #   ping   |             |        |          |         |
-    if USE_GUI:
-        # start a new window
-        master = tk.Toplevel()
-        master.title("Sparki Senses")
+    #   ping   |             |        |          | moving  |
+    try:
+        if sys.version_info[0] >= 3:
+            import PySimpleGUI as sg
+        else:
+            import PySimpleGUI27 as sg
+        
+        robot_name = getName()
+        
+        print("{} will not respond to other commands until the senses window is closed".format(robot_name))
+        
+        # 1st column: space, line, light, space, space, mag, accel, space, ping
+        col1 = [
+                   [ sg.Text('') ],
+                   [ sg.Text('line') ],
+                   [ sg.Text('light') ],
+                   [ sg.Text('') ],
+                   [ sg.Text('') ],
+                   [ sg.Text('mag') ],
+                   [ sg.Text('accel') ],
+                   [ sg.Text('') ],
+                   [ sg.Text('ping') ]
+               ]
 
-        updatePause = 2000  # time in milliseconds to update the window
+        # 2nd column: left edge, le value, space, space, space, space, space, space, ping value
+        col2 = [
+                   [ sg.Text('left edge') ],
+                   [ sg.Text('   ', key='_LEDGE_VALUE_', size=(3,1)) ],
+                   [ sg.Text('') ],
+                   [ sg.Text('') ],
+                   [ sg.Text('') ],
+                   [ sg.Text('') ],
+                   [ sg.Text('') ],
+                   [ sg.Text('') ],
+                   [ sg.Text('   ', key='_PING_VALUE_', size=(3,1)) ]
+               ]
 
-        # we'll use the grid layout manager
-        # top row
-        tk.Label(master, text="left edge").grid(row=0, column=1)
-        tk.Label(master, text="left").grid(row=0, column=2)
-        tk.Label(master, text="center").grid(row=0, column=3)
-        tk.Label(master, text="right").grid(row=0, column=4)
-        tk.Label(master, text="right edge").grid(row=0, column=5)
+        # 3rd column: left, l line value, l light value, space, X, X mag, X accel, space, space
+        col3 = [
+                   [ sg.Text('left') ],
+                   [ sg.Text('   ', key='_LLINE_VALUE_', size=(3,1)) ],
+                   [ sg.Text('   ', key='_LLIGHT_VALUE_', size=(3,1)) ],
+                   [ sg.Text('') ],
+                   [ sg.Text('X') ],
+                   [ sg.Text('   ', key='_XMAG_VALUE_', size=(5,1)) ],
+                   [ sg.Text('   ', key='_XACCEL_VALUE_', size=(5,1)) ],
+                   [ sg.Text('') ],
+                   [ sg.Text('') ]
+               ]
+ 
+        # 4th column: center, c line value, c light value, space, Y, Y mag, Y accel, space, space
+        col4 = [
+                   [ sg.Text('center') ],
+                   [ sg.Text('   ', key='_CLINE_VALUE_', size=(3,1)) ],
+                   [ sg.Text('   ', key='_CLIGHT_VALUE_', size=(3,1)) ],
+                   [ sg.Text('') ],
+                   [ sg.Text('Y') ],
+                   [ sg.Text('   ', key='_YMAG_VALUE_', size=(5,1)) ],
+                   [ sg.Text('   ', key='_YACCEL_VALUE_', size=(5,1)) ],
+                   [ sg.Text('') ],
+                   [ sg.Text('') ]
+               ]
+ 
+        # 5th column: right, r line value, r light value, space, Z, Z mag, Z accel, space, moving
+        col5 = [
+                   [ sg.Text('right') ],
+                   [ sg.Text('   ', key='_RLINE_VALUE_', size=(3,1)) ],
+                   [ sg.Text('   ', key='_RLIGHT_VALUE_', size=(3,1)) ],
+                   [ sg.Text('') ],
+                   [ sg.Text('Z') ],
+                   [ sg.Text('   ', key='_ZMAG_VALUE_', size=(5,1)) ],
+                   [ sg.Text('   ', key='_ZACCEL_VALUE_', size=(5,1)) ],
+                   [ sg.Text('') ],
+                   [ sg.Text('moving?') ]
+               ]
+ 
+        # 6th column: right edge, re value, space, space, compass, compass value, space, space, moving value
+        col6 = [
+                   [ sg.Text('right edge') ],
+                   [ sg.Text('   ', key='_REDGE_VALUE_', size=(3,1)) ],
+                   [ sg.Text('') ],
+                   [ sg.Text('') ],
+                   [ sg.Text('compass') ],
+                   [ sg.Text('   ', key='_COMPASS_VALUE_', size=(5,1)) ],
+                   [ sg.Text('') ],
+                   [ sg.Text('') ],
+                   [ sg.Text('   ', key='_MOVING_VALUE_', size=(3,1)) ]
+               ]
+        
+        layout = [ [ sg.Text("{}'s senses".format(robot_name)) ],
+                   [ sg.Column(col1, element_justification = "center"), sg.Column(col2, element_justification = "center"),
+                     sg.Column(col3, element_justification = "center"), sg.Column(col4, element_justification = "center"),
+                     sg.Column(col5, element_justification = "center"), sg.Column(col6, element_justification = "center") ],
+                   [ sg.Button('Exit') ],
+                   [ sg.Text("You must close this window to give other commands to {}".format(robot_name))] ]
+        
+        window = sg.Window("Sparki senses", layout, auto_size_text = True, keep_on_top = True,
+                           grab_anywhere = True, auto_size_buttons = True, resizable = True,
+                           element_justification = "center")
+        
+        pause = 2000 # length of time to timeout window in milliseconds
+        
+        while True:
+            event, values = window.Read(timeout = pause)
+            
+            if event is None or event == 'Exit':
+                break # user closed the window
+            else:
+                # update the values
+                ledge, lline, cline, rline, redge = getLine()
+                llight, clight, rlight = getLight()
+                
+                window['_LEDGE_VALUE_'].update(ledge)
+                window['_LLINE_VALUE_'].update(lline)
+                window['_CLINE_VALUE_'].update(cline)
+                window['_RLINE_VALUE_'].update(rline)
+                window['_REDGE_VALUE_'].update(redge)
 
-        # 2nd row
-        tk.Label(master, text="line").grid(row=1, column=0)
-        senLinLeftEdge = tk.StringVar()
-        senLinLeft = tk.StringVar()
-        senLinCenter = tk.StringVar()
-        senLinRight = tk.StringVar()
-        senLinRightEdge = tk.StringVar()
-        tk.Label(master, textvariable=senLinLeftEdge).grid(row=1, column=1)
-        tk.Label(master, textvariable=senLinLeft).grid(row=1, column=2)
-        tk.Label(master, textvariable=senLinCenter).grid(row=1, column=3)
-        tk.Label(master, textvariable=senLinRight).grid(row=1, column=4)
-        tk.Label(master, textvariable=senLinRightEdge).grid(row=1, column=5)
+                window['_LLIGHT_VALUE_'].update(llight)
+                window['_CLIGHT_VALUE_'].update(clight)
+                window['_RLIGHT_VALUE_'].update(rlight)
 
-        # 3rd row
-        tk.Label(master, text="light").grid(row=2, column=0)
-        senLightLeft = tk.StringVar()
-        senLightCenter = tk.StringVar()
-        senLightRight = tk.StringVar()
-        tk.Label(master, textvariable=senLightLeft).grid(row=2, column=2)
-        tk.Label(master, textvariable=senLightCenter).grid(row=2, column=3)
-        tk.Label(master, textvariable=senLightRight).grid(row=2, column=4)
+                if not NO_MAG:
+                    xmag, ymag, zmag = getMag()
+                    window['_XMAG_VALUE_'].update(xmag)
+                    window['_YMAG_VALUE_'].update(ymag)
+                    window['_ZMAG_VALUE_'].update(zmag)
+                    window['_COMPASS_VALUE_'].update(compass())
 
-        # 4th row - nada
+                if not NO_ACCEL:
+                    xaccel, yaccel, zaccel = getAccel()
+                    window['_XACCEL_VALUE_'].update(xaccel)
+                    window['_YACCEL_VALUE_'].update(yaccel)
+                    window['_ZACCEL_VALUE_'].update(zaccel)
 
-        # 5th row
-        if not NO_MAG and not NO_ACCEL:
-            tk.Label(master, text="X").grid(row=4, column=2)
-            tk.Label(master, text="Y").grid(row=4, column=3)
-            tk.Label(master, text="Z").grid(row=4, column=4)
-            tk.Label(master, text="compass").grid(row=4, column=5)
+                window['_PING_VALUE_'].update(ping())
 
-        # 6th row
-        if not NO_MAG:
-            tk.Label(master, text="mag").grid(row=5, column=0)
-            senMagX = tk.StringVar()
-            senMagY = tk.StringVar()
-            senMagZ = tk.StringVar()
-            senCompass = tk.StringVar()
-            tk.Label(master, textvariable=senMagX).grid(row=5, column=2)
-            tk.Label(master, textvariable=senMagY).grid(row=5, column=3)
-            tk.Label(master, textvariable=senMagZ).grid(row=5, column=4)
-            tk.Label(master, textvariable=senCompass).grid(row=5, column=5)
-
-        # 7th row
-        if not NO_ACCEL:
-            tk.Label(master, text="accel").grid(row=6, column=0)
-            senAccelX = tk.StringVar()
-            senAccelY = tk.StringVar()
-            senAccelZ = tk.StringVar()
-            tk.Label(master, textvariable=senAccelX).grid(row=6, column=2)
-            tk.Label(master, textvariable=senAccelY).grid(row=6, column=3)
-            tk.Label(master, textvariable=senAccelZ).grid(row=6, column=4)
-
-        # 8th row - nada
-
-        # 9th row
-        tk.Label(master, text="ping").grid(row=8, column=0)
-        senPing = tk.StringVar()
-        tk.Label(master, textvariable=senPing).grid(row=8, column=1)
-
-        # weights for resizing
-        for i in range(6):
-            master.columnconfigure(i, weight=1)
-
-        for i in range(9):
-            master.rowconfigure(i, weight=1)
-
-        # we're going to define a function inside a function, because we can!
-        # more than that, this function is meaningless outside of this window -- we could create a class
-        # to handle whole function, but because reusability here is limited and the code is straightforward,
-        # we'll just do it like this
-        def sensesUpdate():
-            senUpLines = getLine()
-            printDebug("In sensesUpdate, senUpLines = " + str(senUpLines), DEBUG_DEBUG)
-
-            senLinLeftEdge.set(senUpLines[0])
-            senLinLeft.set(senUpLines[1])
-            senLinCenter.set(senUpLines[2])
-            senLinRight.set(senUpLines[3])
-            senLinRightEdge.set(senUpLines[4])
-
-            senUpLights = getLight()
-            printDebug("In sensesUpdate, senUpLights = " + str(senUpLights), DEBUG_DEBUG)
-
-            senLightLeft.set(senUpLights[0])
-            senLightCenter.set(senUpLights[1])
-            senLightRight.set(senUpLights[2])
-
-            if not NO_MAG:
-                senUpMag = getMag()
-                printDebug("In sensesUpdate, senUpMag = " + str(senUpMag), DEBUG_DEBUG)
-
-                senMagX.set(senUpMag[0])
-                senMagY.set(senUpMag[1])
-                senMagZ.set(senUpMag[2])
-                senCompass.set(compass())
-
-            if not NO_ACCEL:
-                senUpAccel = getAccel()
-                printDebug("In sensesUpdate, senUpAccel = " + str(senUpAccel), DEBUG_DEBUG)
-
-                senAccelX.set(senUpAccel[0])
-                senAccelY.set(senUpAccel[1])
-                senAccelZ.set(senUpAccel[2])
-
-            senPing.set(ping())
-            master.after(updatePause, sensesUpdate)  # update the window every updatePause milliseconds
-
-        sensesUpdate()
-        print("Sparki will not respond to other commands until the senses window is closed")
-        master.after(updatePause, sensesUpdate)  # schedule the update of the window
-        master.lift()  # lift this window to the front to make it more visible
-        master.wait_window(master)  # wait until this window is destroyed to continue executing
-        # end USE_GUI
-    else:
+                if isMoving():
+                    window['_MOVING_VALUE_'].update("Yes")
+                else:
+                    window['_MOVING_VALUE_'].update("No")
+            # end update else
+        window.close()
+        
+    except Exception as err:
+        printDebug("No gui for senses() or other error in senses()", DEBUG_CRITICAL)
+        printDebug(str(err), DEBUG_DEBUG)
         senses_text()
 
-
+    print("senses() ended")
 ## end senses() ##
 
 
@@ -2259,21 +2110,7 @@ def setAngle(newAngle=0):
     degrees_turned = newAngle
 
 
-def setDebug(level):
-    """ Sets the debug (in Python) to level
-
-        arguments:
-        level - int constant from the logging module (e.g. logging.DEBUG, logging.INFO, logging.WARN, logging.ERROR, logging.CRITICAL)
-
-        returns:
-        none
-    """
-    global sparki_logger, sparki_std_handler
-
-    printDebug("In setDebug, new logging level is " + str(level), logging.INFO)
-
-    sparki_logger.setLevel(level)
-    sparki_std_handler.setLevel(level)
+setDebug = setGlobalDebug
 
 
 def setLEDBack(brightness):

--- a/sparki_learning/sparki_myro.py
+++ b/sparki_learning/sparki_myro.py
@@ -32,8 +32,7 @@ from sparki_learning.util import *
 
 # try to import tkinter -- but make a note if we can't
 try:
-    import tkinter as tk  # for the senses, joystick, ask, and askQuestion functions
-    import tkinter.filedialog  # only used in pickAFile()
+    import tkinter as tk  # for senses and joystick
 
     root = tk.Tk()
     root.withdraw()  # hide the main window -- we're not going to use it
@@ -239,37 +238,6 @@ ypos = 0  # variables keep track of the current x,y position of the robot; each 
 
 ########### INTERNAL FUNCTIONS ###########
 # these functions are intended to be used by the library itself
-def askQuestion_text(message, options, caseSensitive=True):
-    """ Gets a string from the user, which must be one of the options -- prints message
-
-        arguments:
-        message - string to print to prompt the user
-        options - list of options for the user to choose
-        caseSensitive - boolean, if True, response must match case
-
-        returns:
-        string response from the user (if caseSentitive is False, this will always be a lower case string)
-    """
-    if not caseSensitive:  # if we're not caseSensitive, make the options lower case
-        working_options = [s.lower() for s in options]
-    else:
-        working_options = options
-
-    result = input(message)
-
-    if not caseSensitive:
-        result = result.lower()
-
-    while result not in working_options:
-        print("Your answer must be one of the following: " + str(options))
-        result = input(message)
-
-        if not caseSensitive:
-            result = result.lower()
-
-    return result
-
-
 def bluetoothRead():
     """ Returns the bluetooth address of the robot (if it has been previously stored)
     
@@ -654,62 +622,6 @@ def waitForSync():
 
 ###################### SPARKI MYRO FUNCTIONS ######################
 # These functions are intended to be called by users of this library        
-def askQuestion(message, options, mytitle="Question"):
-    """ Gets input from the user -- prints message and displays buttons with options
-
-        arguments:
-        message - string to print to prompt the user
-        options - a list of strings which could be the response
-        mytitle - title for the window (defaults to Question)
-
-        returns:
-        string response from the user
-    """
-    global root
-    printDebug("In askQuestion", DEBUG_INFO)
-
-    try:
-        choice = tk.StringVar()  # tk has its own kind of string
-        choice.set(options[0])  # default to the top answer
-        question = tk.StringVar()
-        question.set(message)
-
-        # start a new window
-        questionWindow = tk.Toplevel(root)
-        questionWindow.title(mytitle)
-
-        # create sections to put in the data, and use the pack layout manager
-        questionFrame = tk.Frame(questionWindow)
-        answersFrame = tk.Frame(questionWindow)
-        buttonFrame = tk.Frame(questionWindow)
-
-        questionFrame.pack(expand=tk.TRUE, fill=tk.BOTH, side=tk.TOP)
-        answersFrame.pack(expand=tk.TRUE, fill=tk.BOTH)
-        buttonFrame.pack(expand=tk.TRUE, fill=tk.BOTH, side=tk.BOTTOM)
-
-        # put question label in questionFrame
-        questionLabel = tk.Label(questionFrame, textvariable=question)
-        questionLabel.pack()
-
-        # put answers radio buttons in answersFrame
-        for option in options:
-            b = tk.Radiobutton(answersFrame, text=option, variable=choice, value=option)
-            b.pack(anchor=tk.W)
-
-        # put OK button in button frame
-        okButton = tk.Button(buttonFrame, text="OK", command=lambda: questionWindow.destroy())
-        okButton.pack()
-
-        questionWindow.lift()  # move the window to the top to make it more visible
-        questionWindow.wait_window(questionWindow)  # wait for this window to be destroyed (closed) before moving on
-
-        result = choice.get()
-    except:
-        result = askQuestion_text(message, options, False)
-
-    return result
-
-
 def backward(speed, time=-1):
     """ Moves backward at speed for time; time is optional
     
@@ -2698,28 +2610,6 @@ def waitNoop(wait_time):
                 time_remaining)  # in Python >= 3.5, it will wait at least wait_time seconds; prior to that it could be less
         else:
             time.sleep(sleepTime)
-
-
-def yesorno(message):
-    """ Gets the string 'yes' or 'no' from the user -- prints message
-
-        arguments:
-        message - string to print to prompt the user
-
-        returns:
-        string response from the user
-    """
-    printDebug("In yesorno", DEBUG_INFO)
-
-    if USE_GUI:
-        try:
-            result = askQuestion(message, ["yes", "no"], "Yes or No?")
-        except:
-            result = askQuestion_text(message, ["yes", "no", "y", "n"], False)
-
-        return result
-    else:
-        return askQuestion_text(message, ["yes", "no", "y", "n"], False)
 
 
 ###################### END OF SPARKI MYRO FUNCTIONS ######################

--- a/sparki_learning/sparki_myro.py
+++ b/sparki_learning/sparki_myro.py
@@ -654,67 +654,6 @@ def waitForSync():
 
 ###################### SPARKI MYRO FUNCTIONS ######################
 # These functions are intended to be called by users of this library        
-def ask(message, mytitle="Question"):
-    """ Gets input from the user -- prints message
-
-        arguments:
-        message - string to print to prompt the user
-        mytitle - title for the window (defaults to Question)
-
-        returns:
-        string response from the user
-    """
-    global root
-    printDebug("In ask", DEBUG_INFO)
-
-    try:
-        question = tk.StringVar()
-        question.set(message)
-        entryText = tk.StringVar()  # we could use this to type default text
-
-        # start a new window
-        questionWindow = tk.Toplevel(root)
-        questionWindow.title(mytitle)
-
-        # create sections to put in the data, and use the pack layout manager
-        questionFrame = tk.Frame(questionWindow)
-        entryFrame = tk.Frame(questionWindow)
-        buttonFrame = tk.Frame(questionWindow)
-
-        questionFrame.pack(expand=tk.TRUE, fill=tk.BOTH, side=tk.TOP)
-        entryFrame.pack(expand=tk.TRUE, fill=tk.BOTH)
-        buttonFrame.pack(expand=tk.TRUE, fill=tk.BOTH, side=tk.BOTTOM)
-
-        # put question label in questionFrame
-        questionLabel = tk.Label(questionFrame, textvariable=question)
-        questionLabel.pack()
-
-        # in order to accept the return button in textEntry, we have to create a function
-        # to consume the event
-        def doneAction(event):
-            questionWindow.destroy()
-
-        # put entry blank in entryFrame
-        textEntry = tk.Entry(entryFrame, textvariable=entryText)
-        textEntry.bind('<Return>', doneAction)  # make it so if the use presses enter, we accept the data
-        textEntry.pack()
-
-        # put OK button in button frame
-        okButton = tk.Button(buttonFrame, text="OK", command=lambda: questionWindow.destroy())
-        okButton.pack()
-
-        questionWindow.lift()  # move the window to the top to make it more visible
-        textEntry.focus_set()  # grab the focus
-        questionWindow.wait_window(questionWindow)  # wait for this window to be destroyed (closed) before moving on
-
-        result = entryText.get()
-    except Exception as err:
-        printDebug(str(err), DEBUG_DEBUG)
-        result = input(message)
-
-    return result
-
-
 def askQuestion(message, options, mytitle="Question"):
     """ Gets input from the user -- prints message and displays buttons with options
 
@@ -2096,25 +2035,6 @@ def noop():
         printDebug("no op is not available on sparki; simulating", DEBUG_WARN)
         setStatusLED("on")
         setStatusLED("off")
-
-
-def pickAFile():
-    """ Gets the path to a file picked by the user
-
-        arguments:
-        none
-
-        returns:
-        string path to the file
-    """
-    printDebug("In pickAFile", DEBUG_INFO)
-
-    try:
-        result = tkinter.filedialog.askopenfilename()
-    except:
-        result = input("What is the path to the file? ")
-
-    return result
 
 
 def ping():

--- a/sparki_learning/util.py
+++ b/sparki_learning/util.py
@@ -7,7 +7,7 @@
 #
 # written by Jeremy Eglen
 # Created: November 12, 2019 (some functions are older -- this is the original date of this file)
-# Last Modified: November 13, 2019
+# Last Modified: November 14, 2019
 from __future__ import division, print_function
 
 import sys
@@ -159,13 +159,13 @@ def humanTime():
     return time.ctime()
 
 
-def printDebug(message, level=DEBUG_ERROR, stream=sys.stderr):
+def printDebug(message, level=DEBUG_ERROR, myfile=sys.stderr):
     """ Prints message to stream if level is less than or equal to GLOBAL_DEBUG
     
         arguments:
         message - the message to print
         level - the level of the error (lower numbers are more severe - default DEBUG_ERROR [2])
-        stream - the stream to which we should print (default stderr)
+        myfile - the stream to which we should print (default stderr)
         
         returns:
         nothing
@@ -173,7 +173,7 @@ def printDebug(message, level=DEBUG_ERROR, stream=sys.stderr):
     global GLOBAL_DEBUG
     
     if level <= GLOBAL_DEBUG:
-        print("[{}]/{} --- {}".format(time.ctime(), level, message), file=stream)
+        print("[{}]/{} --- {}".format(time.ctime(), level, message), file=myfile)
 
 
 def setGlobalDebug(new_level):
@@ -228,3 +228,15 @@ def wrapAngle(angle):
         return angle % 360
     else:
         return angle % -360
+
+
+def main():
+    print("This is intended to be used as a library -- your code should call this file by importing the library, e.g.")
+    print("from sparki_learning.util import *")
+    print("or")
+    print("import sparki_learning.util")
+    print("Exiting...")
+
+
+if __name__ == "__main__":
+    main()

--- a/sparki_learning/util.py
+++ b/sparki_learning/util.py
@@ -7,7 +7,7 @@
 #
 # written by Jeremy Eglen
 # Created: November 12, 2019 (some functions are older -- this is the original date of this file)
-# Last Modified: November 14, 2019
+# Last Modified: November 18, 2019
 from __future__ import division, print_function
 
 import sys
@@ -22,9 +22,10 @@ DEBUG_WARN = 3  # a generally sane default; reports issues that may be mistakes,
 DEBUG_ERROR = 2  # reports something contrary to the API
 DEBUG_CRITICAL = 1  # reports an error which interferes with proper or consistent operation
 DEBUG_ALWAYS = 0  # should always be reported
+# ***** END DEBUG CONSTANTS ***** #
 
 GLOBAL_DEBUG = DEBUG_ERROR
-# ***** END DEBUG CONSTANTS ***** #
+
 
 def bluetoothValidate(address):
     """ Returns True if the string argument appears to be a Bluetooth address (strictly speaking, a MAC address)
@@ -130,7 +131,7 @@ def flrange(start, stop, step):
         yield:
         float - the next value in the range
     """
-    printDebug("In flrange, start={}; stop={}; step={}".format(start, stop, step), sparki_learning.util.DEBUG_INFO)
+    printDebug("In flrange, start={}; stop={}; step={}".format(start, stop, step), DEBUG_INFO)
 
     if step > 0:
         while start < stop:

--- a/sparki_learning/util.py
+++ b/sparki_learning/util.py
@@ -130,6 +130,8 @@ def flrange(start, stop, step):
         yield:
         float - the next value in the range
     """
+    printDebug("In flrange, start={}; stop={}; step={}".format(start, stop, step), sparki_learning.util.DEBUG_INFO)
+
     if step > 0:
         while start < stop:
             yield start  # yield is a special keyword which is something like return, but behaves very differently


### PR DESCRIPTION
This version breaks out the gui functions (ask, askQuestion, pickAFile) which are not specific to sparki_learning into their own module. These functions now all use the PySimpleGUI library, which is now a requirement for the sparki_learning library.

The joystick() and senses() functions have been left in sparki_myro.py, but they have also been updated to use PySimpleGUI. 

I've done the switch to PySimpleGUI for a couple of reasons: 1) tkinter syntax sucks, and 2) there is the potential to use other "backends" besides tkinter by using PySimpleGUI.

The constants which were located in sparki_myro.py have been moved into their own constants.py module. I am attempting to ensure that sparki_myro.py only has the code needed to control a single robot, in the hopes it will make an object oriented conversion easier.